### PR TITLE
type(pd.NaT) instead of pd._libs.tslib.NaTType

### DIFF
--- a/jardin/query_builders.py
+++ b/jardin/query_builders.py
@@ -120,7 +120,7 @@ class SelectQueryBuilder(PGQueryBuilder):
                     self.where_values[key] = v
                     keys += [':' + key]
                 return '(' + ', '.join(keys) + ')'
-        
+
         key = self.where_key(key)
         self.where_values[key] = value
 
@@ -246,7 +246,7 @@ class WriteQueryBuilder(PGQueryBuilder):
             kw_values = kw_values.attributes
         if isinstance(kw_values, dict):
             kw_values = [kw_values]
-        
+
         kw_values = pd.DataFrame(kw_values).copy()
         kw_values.reset_index(drop=True, inplace=True)
 
@@ -281,7 +281,7 @@ class WriteQueryBuilder(PGQueryBuilder):
                 if isinstance(v, pd.Timestamp) and ((self.scheme == 'mysql' \
                     and sys.version_info[0] == 3) or self.scheme == 'sqlite'):
                     v = v.strftime('%Y-%m-%d %H:%M:%S')
-                if isinstance(v, pd._libs.tslib.NaTType):
+                if isinstance(v, type(pd.NaT)):
                     v = None
                 if isinstance(v, float) and np.isnan(v):
                     v = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ freezegun==0.3.10
 PyMySQL==0.8.0
 mysqlclient==1.3.12
 snowflake-connector-python==1.5.6
+mock==2.0.0

--- a/tests/support/mydatetime.py
+++ b/tests/support/mydatetime.py
@@ -1,0 +1,6 @@
+import datetime
+
+class _mydatetime(datetime.datetime):
+    @property
+    def nanosecond(self):
+        return 0

--- a/tests/test_jardin.py
+++ b/tests/test_jardin.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from mock import patch
 from time import sleep
 from freezegun import freeze_time
 from datetime import datetime, timedelta
@@ -14,7 +14,7 @@ class User(JardinTestModel): pass
 
 class TestModel(unittest.TestCase):
 
-    @mock.patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
+    @patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
     @transaction(model=User)
     def test_created_at_updated_at(self):
         user = User.insert(values={'name': 'Jardinier'})

--- a/tests/test_jardin.py
+++ b/tests/test_jardin.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from time import sleep
 from freezegun import freeze_time
 from datetime import datetime, timedelta
@@ -6,13 +7,14 @@ import pandas as pd
 
 from tests import transaction
 from tests.models import JardinTestModel
-
+from support.mydatetime import _mydatetime
 
 class User(JardinTestModel): pass
 
 
 class TestModel(unittest.TestCase):
 
+    @mock.patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
     @transaction(model=User)
     def test_created_at_updated_at(self):
         user = User.insert(values={'name': 'Jardinier'})
@@ -35,7 +37,7 @@ class TestModel(unittest.TestCase):
         if User.db().db_config.scheme == 'sqlite':
             User.query(
                 sql='CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name varchar(256));'
-                )            
+                )
         else:
             User.query(
                 sql='CREATE TABLE users (id serial PRIMARY KEY, name varchar(256));'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 import pandas as pd
 from freezegun import freeze_time
 from datetime import datetime, timedelta
@@ -11,6 +12,7 @@ from jardin.model import RecordNotPersisted
 from tests import transaction
 
 from tests.models import JardinTestModel
+from support.mydatetime import _mydatetime
 
 
 class Project(JardinTestModel):
@@ -163,6 +165,7 @@ class TestModel(unittest.TestCase):
         users = User.select(select='name', group='name', having='COUNT(*) > 1')
         self.assertEqual(len(users), 1)
 
+    @mock.patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
     @transaction(model=User)
     def test_touch(self):
         user = User.insert(values={'name': 'Jardin'})

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from mock import patch
 import pandas as pd
 from freezegun import freeze_time
 from datetime import datetime, timedelta
@@ -165,7 +165,7 @@ class TestModel(unittest.TestCase):
         users = User.select(select='name', group='name', having='COUNT(*) > 1')
         self.assertEqual(len(users), 1)
 
-    @mock.patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
+    @patch('pandas.datetime', _mydatetime) #hack to fix https://github.com/spulec/freezegun/issues/242
     @transaction(model=User)
     def test_touch(self):
         user = User.insert(values={'name': 'Jardin'})


### PR DESCRIPTION
`The type import pandas.tslib.NaTType is deprecated and can be replaced by using type(pandas.NaT) (GH16146)`

It is breaking when using jardin with latest pandas 0.23.

from https://pandas-docs.github.io/pandas-docs-travis/whatsnew.html
https://github.com/pandas-dev/pandas/pull/16146

