### PR TITLE
Remove code that only ran on Python 2.x

### DIFF
--- a/jardin/database/database_config.py
+++ b/jardin/database/database_config.py
@@ -1,11 +1,3 @@
-from future.standard_library import install_aliases
-install_aliases()
-
-import sys
-if sys.version_info[0] >= 3:
-    unicode = str
-
-
 from urllib.parse import urlparse
 
 
@@ -17,7 +9,7 @@ class DatabaseConfig(object):
     lowercase_columns = False
 
     def __init__(self, config):
-        if isinstance(config, str) or isinstance(config, unicode):
+        if isinstance(config, str):
             db = urlparse(config)
             self.scheme = db.scheme
             self.username = db.username

--- a/jardin/database/drivers/mysql.py
+++ b/jardin/database/drivers/mysql.py
@@ -1,8 +1,4 @@
-import sys
-if sys.version_info[0] < 3:
-    import MySQLdb
-else:
-    import pymysql as MySQLdb
+import pymysql
 
 from jardin.tools import retry
 from jardin.database.base import BaseConnection
@@ -31,7 +27,7 @@ class Lexicon(BaseLexicon):
 
 class DatabaseConnection(BaseConnection):
 
-    DRIVER = MySQLdb
+    DRIVER = pymysql
     LEXICON = Lexicon
 
     @retry(DRIVER.OperationalError, tries=3)

--- a/jardin/query_builders.py
+++ b/jardin/query_builders.py
@@ -277,9 +277,7 @@ class WriteQueryBuilder(PGQueryBuilder):
                     v = bool(v)
                 if isinstance(v, np.datetime64) and np.isnat(v):
                     v = None
-                # Foul hack for pymysql
-                if isinstance(v, pd.Timestamp) and ((self.scheme == 'mysql' \
-                    and sys.version_info[0] == 3) or self.scheme == 'sqlite'):
+                if isinstance(v, pd.Timestamp) and self.scheme in ['mysql', 'sqlite']:
                     v = v.strftime('%Y-%m-%d %H:%M:%S')
                 if isinstance(v, type(pd.NaT)):
                     v = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ psycopg2>=2.7.7
 future==0.16.0
 freezegun==0.3.12
 PyMySQL==0.8.0
-mysqlclient==1.3.12
 snowflake-connector-python==1.5.6
 inflect==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
       classifiers = [
       'Intended Audience :: Developers',
       'License :: OSI Approved :: MIT License',
-      'Programming Language :: Python :: 2',
       'Programming Language :: Python :: 3',
       'Programming Language :: Python :: 3.5',
       'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
I noticed that there was still some Python 2.x compatibility code laying around, but according to `setup.py`, this library is Python 3.x only. So I removed the old stuff.