### PR TITLE
Re-raise general exceptions

### DIFF
--- a/jardin/database/base.py
+++ b/jardin/database/base.py
@@ -27,8 +27,9 @@ class BaseConnection(object):
         except self.DRIVER.InterfaceError:
             self._connection = None
             raise
-        except Exception as e:
+        except Exception:
             self.rollback()
+            raise
         finally:
             if self.pool is not None and self.autocommit:
                 key = threading.current_thread().ident


### PR DESCRIPTION
This appears to have been an accidental regression in commit 80671e2.

I split this off from my other PR because I think we should make a new release with just this fix and deploy it. Right now there may be a lot of exceptions which we aren't seeing in Rollbar.