### PR TITLE
[Step 3] Refactor `BaseConnection` and subclasses

### DIFF
--- a/jardin/database/__init__.py
+++ b/jardin/database/__init__.py
@@ -12,50 +12,50 @@ import jardin.config as config
 from jardin.database.database_config import DatabaseConfig
 
 
-class UnsupportedDriver(Exception): pass
+class UnsupportedDatabase(Exception): pass
 
 
-class DatabaseConnections(object):
+class Datasources(object):
 
-    _db_configs = {}          # For each db_name, it caches connection info of one or many DB instances
+    _db_configs = {}       # For each db_name, it caches connection info of one or many DB instances
 
-    _connections = {}         # For each db_name, it caches one or many connections
+    _clients = {}          # For each db_name, it caches one or many clients
 
-    _active_connections = {}  # For each db_name, it caches only ONE actively used connection. Active connection
-                              # can only be changed by a call to self.shuffle_connections(). The idea is to provide
-                              # connection stickiness during the lifetime of a session/task/job, etc.
+    _active_clients = {}   # For each db_name, it caches only ONE actively used client. Active client
+                           # can only be changed by a call to self.shuffle_clients(). The idea is to provide
+                           # connection stickiness during the lifetime of a session/task/job, etc.
 
     SUPPORTED_SCHEMES = ('postgres', 'mysql', 'sqlite', 'snowflake', 'redshift')
 
     @classmethod
-    def connection(self, db_name):
-        if db_name not in self._active_connections:
-            connections = self._connections.get(db_name)
-            if connections is None:
-                connections = self.build_connections(db_name)
-                self._connections[db_name] = connections
-            c = connections[0] if len(connections) == 1 else random.choice(connections)
-            self.log_db_connection(db_name, c.db_config)
-            self._active_connections[db_name] = c
-        return self._active_connections[db_name]
+    def active_client(self, db_name):
+        if db_name not in self._active_clients:
+            clients = self._clients.get(db_name)
+            if clients is None:
+                clients = self.build_clients(db_name)
+                self._clients[db_name] = clients
+            c = clients[0] if len(clients) == 1 else random.choice(clients)
+            self.log_datasource(db_name, c.db_config)
+            self._active_clients[db_name] = c
+        return self._active_clients[db_name]
 
     @classmethod
-    def build_connections(self, name):
-        connections = []
+    def build_clients(self, name):
+        clients = []
         configs = self.db_configs(name)
         for db in configs:
             if db.scheme not in self.SUPPORTED_SCHEMES:
-                raise UnsupportedDriver('%s is not a supported driver' % db.scheme)
+                raise UnsupportedDatabase('%s is not a supported database' % db.scheme)
             elif db.scheme == 'postgres' or db.scheme == 'redshift':
-                import jardin.database.drivers.pg as driver
+                import jardin.database.clients.pg as impl
             elif db.scheme == 'mysql':
-                import jardin.database.drivers.mysql as driver
+                import jardin.database.clients.mysql as impl
             elif db.scheme == 'sqlite':
-                import jardin.database.drivers.sqlite as driver
+                import jardin.database.clients.sqlite as impl
             elif db.scheme == 'snowflake':
-                import jardin.database.drivers.sf as driver
-            connections.append(driver.DatabaseConnection(db, name))
-        return connections
+                import jardin.database.clients.sf as impl
+            clients.append(impl.DatabaseClient(db, name))
+        return clients
 
     @classmethod
     def db_configs(self, name):
@@ -70,32 +70,33 @@ class DatabaseConnections(object):
         return self._db_configs[name]
 
     @classmethod
-    def shuffle_connections(self):
-        for name, conns in self._connections.items():
+    def shuffle_clients(self):
+        for name, clients in self._clients.items():
             c = None
-            if len(conns) == 1:
-                c = conns[0]
+            if len(clients) == 1:
+                c = clients[0]
             else:
-                active = self._active_connections[name]
-                filtered = list(filter(lambda x: x is not active, conns))
+                active = self._active_clients[name]
+                filtered = list(filter(lambda x: x is not active, clients))
                 c = filtered[0] if len(filtered) == 1 else random.choice(filtered)
-            self.log_db_connection(name, c.db_config)
-            self._active_connections[name] = c
+            self.log_datasource(name, c.db_config)
+            self._active_clients[name] = c
 
     @classmethod
-    def log_db_connection(self, name, db_config):
+    def log_datasource(self, name, db_config):
         host = getattr(db_config, 'host', None) or '_'  # use "_" for both missing attr or None value cases
         port = getattr(db_config, 'port', None) or '_'
         user = getattr(db_config, 'username', None) or '_'
         database = getattr(db_config, 'database', None) or '_'
-        config.logger.debug("[{}]: database connection {}@{}:{}/{}".format(name, user, host, port, database))
+        config.logger.debug("[{}]: datasource {}@{}:{}/{}".format(name, user, host, port, database))
+
 
 def set_defaults(func):
     def wrapper(self, *args, **kwargs):
         kwargs.update(
             model_metadata=self.model_metadata,
-            scheme=self.db.db_config.scheme,
-            lexicon=self.db.lexicon
+            scheme=self.db_client.db_config.scheme,
+            lexicon=self.db_client.lexicon
             )
         return func(self, *args, **kwargs)
     return wrapper
@@ -103,15 +104,15 @@ def set_defaults(func):
 
 class DatabaseAdapter(object):
 
-    def __init__(self, db, model_metadata):
-        self.db = db
+    def __init__(self, db_client, model_metadata):
+        self.db_client = db_client
         self.model_metadata = model_metadata
 
     @set_defaults
     def select(self, **kwargs):
         query = SelectQueryBuilder(**kwargs).query
         config.logger.debug(query)
-        results, columns = self.db.execute(*query, write=False)
+        results, columns = self.db_client.execute(*query, write=False)
         if results is None and columns is None:
             return None
         return pandas.DataFrame.from_records(results, columns=columns, coerce_float=True)
@@ -120,7 +121,7 @@ class DatabaseAdapter(object):
     def write(self, query_builder, **kwargs):
         query = query_builder(**kwargs).query
         config.logger.debug(query)
-        returning_ids = self.db.execute(*query, write=True, **kwargs)
+        returning_ids = self.db_client.execute(*query, write=True, **kwargs)
         if len(returning_ids) > 0:
             return self.select(where={kwargs['primary_key']: returning_ids})
         return None
@@ -135,13 +136,13 @@ class DatabaseAdapter(object):
     def delete(self, **kwargs):
         query = DeleteQueryBuilder(**kwargs).query
         config.logger.debug(query)
-        self.db.execute(*query, write=False)
+        self.db_client.execute(*query, write=False)
 
     @set_defaults
     def raw_query(self, **kwargs):
         query = RawQueryBuilder(**kwargs).query
         config.logger.debug(query)
-        results, columns = self.db.execute(*query, write=False)
+        results, columns = self.db_client.execute(*query, write=False)
         if results is None and columns is None:
             return None
         return pandas.DataFrame.from_records(results, columns=columns, coerce_float=True)

--- a/jardin/database/base.py
+++ b/jardin/database/base.py
@@ -2,7 +2,7 @@ from memoized_property import memoized_property
 import threading
 
 
-class BaseConnection(object):
+class BaseClient(object):
 
     DRIVER = None
     LEXICON = None

--- a/jardin/database/base.py
+++ b/jardin/database/base.py
@@ -28,7 +28,7 @@ class BaseConnection(object):
     def connect_args(self):
         return []
 
-    def get_connection(self):
+    def connect(self):
         return self.DRIVER.connect(*self.connect_args, **self.connect_kwargs)
 
     @memoized_property
@@ -48,7 +48,7 @@ class BaseConnection(object):
         # try to reuse an existing connection or open a new one
         conn = getattr(self._thread_local, 'conn', None)
         if conn is None:
-            conn = self.get_connection()
+            conn = self.connect()
             self._thread_local.conn = conn
 
         try:

--- a/jardin/database/base.py
+++ b/jardin/database/base.py
@@ -1,6 +1,8 @@
+import threading
+import time
 from abc import ABC, abstractmethod
 
-import threading
+MAX_RETRIES = 3
 
 
 class BaseClient(ABC):
@@ -21,7 +23,12 @@ class BaseClient(ABC):
     @property
     @abstractmethod
     def lexicon(self):
-        """Provide an object which normalizes a SQL dialect"""
+        """Provide an object which normalizes a SQL dialect."""\
+
+    @property
+    @abstractmethod
+    def retryable_exceptions(self):
+        """Provide exceptions which may be retried."""
 
     @abstractmethod
     def connect_impl(self, **kwargs):
@@ -31,9 +38,24 @@ class BaseClient(ABC):
     def execute_impl(self, conn, *query):
         """Execute a SQL query and return the cursor."""
 
-    def execute(self, *query, write=False, **kwargs):
-        """Connect to the database (if necessary) and execute a query."""
+    def execute(self, *query, **kwargs):
+        last_exception = None
+        delay = 3
+        for _ in range(MAX_RETRIES):
+            try:
+                return self.execute_once(*query, **kwargs)
+            except self.retryable_exceptions as e:
+                # TODO [kl] comment this out?
+                print(f"{e}, Retrying in {delay} seconds...")
+                time.sleep(delay)
+                delay *= 2
+                last_exception = e
+                continue
+        else:
+            raise last_exception
 
+    def execute_once(self, *query, write=False, **kwargs):
+        """Connect to the database (if necessary) and execute a query."""
         conn = getattr(self._thread_local, 'conn', None)
         if conn is None:
             conn = self.connect_impl(**self.default_connect_kwargs)

--- a/jardin/database/clients/mysql.py
+++ b/jardin/database/clients/mysql.py
@@ -1,6 +1,5 @@
 import pymysql
 
-from jardin.tools import retry
 from jardin.database.base import BaseClient
 from jardin.database.lexicon import BaseLexicon
 
@@ -28,14 +27,13 @@ class Lexicon(BaseLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
+    retryable_exceptions = (pymysql.InterfaceError, pymysql.OperationalError)
 
-    @retry(pymysql.OperationalError, tries=3)
     def connect_impl(self, **default_kwargs):
         kwargs = default_kwargs.copy()
         kwargs.update(autocommit=True)
         return pymysql.connect(**kwargs)
 
-    @retry(pymysql.InterfaceError, tries=3)
     def execute_impl(self, conn, *query):
         cursor = conn.cursor()
         cursor.execute(*query)

--- a/jardin/database/clients/mysql.py
+++ b/jardin/database/clients/mysql.py
@@ -2,7 +2,7 @@ import pymysql
 from memoized_property import memoized_property
 
 from jardin.tools import retry
-from jardin.database.base import BaseConnection
+from jardin.database.base import BaseClient
 from jardin.database.lexicon import BaseLexicon
 
 
@@ -26,12 +26,12 @@ class Lexicon(BaseLexicon):
         return ' '.join([watermark, query])
 
 
-class DatabaseConnection(BaseConnection):
+class DatabaseClient(BaseClient):
 
     DRIVER = pymysql
     LEXICON = Lexicon
 
-    @retry(DRIVER.OperationalError, tries=3)
+    @retry(pymysql.OperationalError, tries=3)
     def connect(self):
         return super().connect()
 
@@ -41,7 +41,7 @@ class DatabaseConnection(BaseConnection):
         kwargs.update(autocommit=True)
         return kwargs
 
-    @retry(DRIVER.InterfaceError, tries=3)
+    @retry(pymysql.InterfaceError, tries=3)
     def execute(self, *query, write=False, **kwargs):
         return super().execute(*query, write=write, **kwargs)
 

--- a/jardin/database/clients/pg.py
+++ b/jardin/database/clients/pg.py
@@ -3,7 +3,7 @@ from psycopg2 import extras
 from memoized_property import memoized_property
 
 from jardin.tools import retry
-from jardin.database.base import BaseConnection
+from jardin.database.base import BaseClient
 from jardin.database.lexicon import BaseLexicon
 import jardin.config as config
 
@@ -41,7 +41,7 @@ class Lexicon(BaseLexicon):
         return [r[primary_key] for r in row_ids]
 
 
-class DatabaseConnection(BaseConnection):
+class DatabaseClient(BaseClient):
 
     DRIVER = pg
     LEXICON = Lexicon

--- a/jardin/database/clients/sf.py
+++ b/jardin/database/clients/sf.py
@@ -4,8 +4,8 @@ from memoized_property import memoized_property
 import snowflake.connector as sf
 
 from jardin.tools import retry
-from jardin.database.drivers.pg import Lexicon as PGLexicon
-from jardin.database.base import BaseConnection
+from jardin.database.clients.pg import Lexicon as PGLexicon
+from jardin.database.base import BaseClient
 
 
 class Lexicon(PGLexicon):
@@ -30,7 +30,7 @@ class Lexicon(PGLexicon):
         return sql, params
 
 
-class DatabaseConnection(BaseConnection):
+class DatabaseClient(BaseClient):
 
     DRIVER = sf
     LEXICON = Lexicon

--- a/jardin/database/clients/sf.py
+++ b/jardin/database/clients/sf.py
@@ -2,7 +2,6 @@ import re
 
 import snowflake.connector as sf
 
-from jardin.tools import retry
 from jardin.database.clients.pg import Lexicon as PGLexicon
 from jardin.database.base import BaseClient
 
@@ -32,8 +31,8 @@ class Lexicon(PGLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
+    retryable_exceptions = (sf.InterfaceError, sf.OperationalError)
 
-    @retry(sf.OperationalError, tries=3)
     def connect_impl(self, **default_kwargs):
         kwargs = dict(
             user=self.db_config.username,
@@ -52,7 +51,6 @@ class DatabaseClient(BaseClient):
 
         return sf.connect(**kwargs)
 
-    @retry(sf.InterfaceError, tries=3)
     def execute_impl(self, conn, *query):
         cursor = conn.cursor()
         cursor.execute(*query)

--- a/jardin/database/clients/sqlite.py
+++ b/jardin/database/clients/sqlite.py
@@ -1,7 +1,7 @@
 import sqlite3
 from memoized_property import memoized_property
 
-from jardin.database.base import BaseConnection
+from jardin.database.base import BaseClient
 from jardin.database.lexicon import BaseLexicon
 
 
@@ -24,7 +24,7 @@ class Lexicon(BaseLexicon):
         return [cursor.lastrowid]
 
 
-class DatabaseConnection(BaseConnection):
+class DatabaseClient(BaseClient):
 
     DRIVER = sqlite3
     LEXICON = Lexicon

--- a/jardin/database/clients/sqlite.py
+++ b/jardin/database/clients/sqlite.py
@@ -1,5 +1,4 @@
 import sqlite3
-from memoized_property import memoized_property
 
 from jardin.database.base import BaseClient
 from jardin.database.lexicon import BaseLexicon
@@ -26,16 +25,13 @@ class Lexicon(BaseLexicon):
 
 class DatabaseClient(BaseClient):
 
-    DRIVER = sqlite3
-    LEXICON = Lexicon
+    lexicon = Lexicon
 
-    @memoized_property
-    def connect_args(self):
-        return [self.db_config.database]
+    def connect_impl(self, **default_kwargs):
+        # autocommit is enabled by setting isolation_level to None
+        return sqlite3.connect(self.db_config.database, isolation_level=None)
 
-    @memoized_property
-    def connect_kwargs(self):
-        return {'isolation_level': None}  # autocommit is enabled by setting isolation_level to None
-
-    def execute(self, *query, write=False, **kwargs):
-        return super().execute(*query, write=write, **kwargs)
+    def execute_impl(self, conn, *query):
+        cursor = conn.cursor()
+        cursor.execute(*query)
+        return cursor

--- a/jardin/database/clients/sqlite.py
+++ b/jardin/database/clients/sqlite.py
@@ -26,6 +26,7 @@ class Lexicon(BaseLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
+    retryable_exceptions = tuple()
 
     def connect_impl(self, **default_kwargs):
         # autocommit is enabled by setting isolation_level to None

--- a/jardin/database/drivers/mysql.py
+++ b/jardin/database/drivers/mysql.py
@@ -33,15 +33,15 @@ class DatabaseConnection(BaseConnection):
 
     @retry(DRIVER.OperationalError, tries=3)
     def connect(self):
-        return super(DatabaseConnection, self).connect()
+        return super().connect()
 
     @memoized_property
     def connect_kwargs(self):
-        kwargs = super(DatabaseConnection, self).connect_kwargs
+        kwargs = super().connect_kwargs
         kwargs.update(autocommit=True)
         return kwargs
 
     @retry(DRIVER.InterfaceError, tries=3)
     def execute(self, *query, write=False, **kwargs):
-        return super(DatabaseConnection, self).execute(*query, write=write, **kwargs)
+        return super().execute(*query, write=write, **kwargs)
 

--- a/jardin/database/drivers/mysql.py
+++ b/jardin/database/drivers/mysql.py
@@ -32,8 +32,8 @@ class DatabaseConnection(BaseConnection):
     LEXICON = Lexicon
 
     @retry(DRIVER.OperationalError, tries=3)
-    def get_connection(self):
-        return super(DatabaseConnection, self).get_connection()
+    def connect(self):
+        return super(DatabaseConnection, self).connect()
 
     @memoized_property
     def connect_kwargs(self):

--- a/jardin/database/drivers/pg.py
+++ b/jardin/database/drivers/pg.py
@@ -48,14 +48,14 @@ class DatabaseConnection(BaseConnection):
 
     @retry(pg.OperationalError, tries=3)
     def connect(self):
-        connection = super(DatabaseConnection, self).connect()
+        connection = super().connect()
         connection.initialize(config.logger)
         connection.autocommit = True
         return connection
 
     @memoized_property
     def connect_kwargs(self):
-        kwargs = super(DatabaseConnection, self).connect_kwargs
+        kwargs = super().connect_kwargs
         kwargs.update(connection_factory=extras.MinTimeLoggingConnection)
         return kwargs
 
@@ -65,4 +65,4 @@ class DatabaseConnection(BaseConnection):
 
     @retry((pg.InterfaceError, pg.extensions.QueryCanceledError), tries=3)
     def execute(self, *query, write=False, **kwargs):
-        return super(DatabaseConnection, self).execute(*query, write=write, **kwargs)
+        return super().execute(*query, write=write, **kwargs)

--- a/jardin/database/drivers/pg.py
+++ b/jardin/database/drivers/pg.py
@@ -47,8 +47,8 @@ class DatabaseConnection(BaseConnection):
     LEXICON = Lexicon
 
     @retry(pg.OperationalError, tries=3)
-    def get_connection(self):
-        connection = super(DatabaseConnection, self).get_connection()
+    def connect(self):
+        connection = super(DatabaseConnection, self).connect()
         connection.initialize(config.logger)
         connection.autocommit = True
         return connection

--- a/jardin/database/drivers/sf.py
+++ b/jardin/database/drivers/sf.py
@@ -55,9 +55,9 @@ class DatabaseConnection(BaseConnection):
 
     @retry(sf.OperationalError, tries=3)
     def connect(self):
-        return super(DatabaseConnection, self).connect()
+        return super().connect()
 
     @retry(sf.InterfaceError, tries=3)
     def execute(self, *query, write=False, **kwargs):
-        return super(DatabaseConnection, self).execute(*query, write=False, **kwargs)
+        return super().execute(*query, write=False, **kwargs)
 

--- a/jardin/database/drivers/sf.py
+++ b/jardin/database/drivers/sf.py
@@ -54,8 +54,8 @@ class DatabaseConnection(BaseConnection):
         return kwargs
 
     @retry(sf.OperationalError, tries=3)
-    def get_connection(self):
-        return super(DatabaseConnection, self).get_connection()
+    def connect(self):
+        return super(DatabaseConnection, self).connect()
 
     @retry(sf.InterfaceError, tries=3)
     def execute(self, *query, write=False, **kwargs):

--- a/jardin/database/drivers/sqlite.py
+++ b/jardin/database/drivers/sqlite.py
@@ -38,4 +38,4 @@ class DatabaseConnection(BaseConnection):
         return {'isolation_level': None}  # autocommit is enabled by setting isolation_level to None
 
     def execute(self, *query, write=False, **kwargs):
-        return super(DatabaseConnection, self).execute(*query, write=write, **kwargs)
+        return super().execute(*query, write=write, **kwargs)

--- a/jardin/database/lexicon.py
+++ b/jardin/database/lexicon.py
@@ -21,7 +21,7 @@ class BaseLexicon(object):
         return ', '.join(values)
 
     @staticmethod
-    def row_ids(db): pass
+    def row_ids(cursor, primary_key): pass
 
     @staticmethod
     def apply_watermark(query, watermark):

--- a/jardin/model.py
+++ b/jardin/model.py
@@ -4,7 +4,7 @@ import re, inspect
 import json
 
 import jardin.config as config
-from jardin.database import DatabaseAdapter, DatabaseConnections
+from jardin.database import DatabaseAdapter, Datasources
 from jardin.tools import soft_del, classorinstancemethod, stack_marker
 from jardin.query import query
 
@@ -249,7 +249,7 @@ class Model(object):
 
         kwargs['stack'] = self.stack_mark(
             inspect.stack(),
-            db_conn=db_adapter.db
+            db_conn=db_adapter.db_client
             )
 
         return self.collection_instance(db_adapter.select(**kwargs))
@@ -492,7 +492,7 @@ class Model(object):
     @classmethod
     def db(self, role='replica', db_name=None):
         name = db_name or self.db_names.get(role)
-        return DatabaseConnections.connection(name)
+        return Datasources.active_client(name)
 
     @classmethod
     def _use_replica(self, **kwargs):
@@ -556,7 +556,7 @@ class Model(object):
             self.model_metadata(include_schema=False)
             )
         return db_adapter.raw_query(
-            sql=db_adapter.db.lexicon.table_schema_query(self._table_name()),
+            sql=db_adapter.db_client.lexicon.table_schema_query(self._table_name()),
             where={'table_name': self._table_name()}
             ).to_dict(orient='records')
 

--- a/jardin/query.py
+++ b/jardin/query.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import inspect
 
-from jardin.database import DatabaseAdapter, DatabaseConnections
+from jardin.database import DatabaseAdapter, Datasources
 from jardin.tools import stack_marker
 
 def query(sql=None, filename=None, extract=None, db=None, **kwargs):
@@ -20,7 +20,7 @@ def query(sql=None, filename=None, extract=None, db=None, **kwargs):
         kwargs['where'] = kwargs['params']
 
     return DatabaseAdapter(
-        DatabaseConnections.connection(db),
+        Datasources.active_client(db),
         None
         ).raw_query(
             sql=sql, filename=filename, **kwargs

--- a/jardin/tools.py
+++ b/jardin/tools.py
@@ -1,7 +1,7 @@
 import itertools
 from operator import is_not
 from functools import partial, wraps
-from jardin.database import DatabaseConnections
+from jardin.database import Datasources
 import time
 
 
@@ -111,4 +111,4 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
     return deco_retry
 
 def reset_session():
-    DatabaseConnections.shuffle_connections()
+    Datasources.shuffle_clients()

--- a/jardin/tools.py
+++ b/jardin/tools.py
@@ -70,45 +70,5 @@ def grouper(iterable, n, fillvalue=None):
 def remove_none(res):
   return filter(partial(is_not, None), res)
 
-def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
-    """Retry calling the decorated function using an exponential backoff.
-    original from: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
-
-    :param ExceptionToCheck: the exception to check. may be a tuple of
-        exceptions to check
-    :type ExceptionToCheck: Exception or tuple
-    :param tries: number of times to try (not retry) before giving up
-    :type tries: int
-    :param delay: initial delay between retries in seconds
-    :type delay: int
-    :param backoff: backoff multiplier e.g. value of 2 will double the delay
-        each retry
-    :type backoff: int
-    :param logger: logger to use. If None, print
-    :type logger: logging.Logger instance
-    """
-    def deco_retry(f):
-
-        @wraps(f)
-        def f_retry(*args, **kwargs):
-            mtries, mdelay = tries, delay
-            while mtries > 1:
-                try:
-                    return f(*args, **kwargs)
-                except ExceptionToCheck as e:
-                    msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
-                    if logger:
-                        logger.warning(msg)
-                    else:
-                        print(msg)
-                    time.sleep(mdelay)
-                    mtries -= 1
-                    mdelay *= backoff
-            return f(*args, **kwargs)
-
-        return f_retry  # true decorator
-
-    return deco_retry
-
 def reset_session():
     Datasources.shuffle_clients()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
       author = 'Emmanuel Turlay',
       license = 'MIT',
       author_email = 'emmanuel@instacart.com',
-      packages = ['jardin', 'jardin.database', 'jardin.database.drivers'],
+      packages = ['jardin', 'jardin.database', 'jardin.database.clients'],
       install_requires = [
       'pandas',
       'numpy',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ class TestTransaction(object):
         self.tables = extra_tables
         if self._model:
             self._model.clear_caches()
-        self._connection = DatabaseConnections.connection('jardin_test')
+        self._connection = Datasources.active_client('jardin_test')
         self.create_table = create_table
 
     def setup(self):
@@ -59,14 +59,14 @@ def transaction(model=None, create_table=True, extra_tables=[]):
     return decorator
 
 
-from jardin.database import DatabaseConnections
+from jardin.database import Datasources
 
 def only_schemes(*schemes):
 
     def decorator(func):
 
         def wrapper(*args, **kwargs):
-            if DatabaseConnections.connection('jardin_test').db_config.scheme in schemes:
+            if Datasources.active_client('jardin_test').db_config.scheme in schemes:
                 return func(*args, **kwargs)
 
         return wrapper

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -57,7 +57,7 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(df.name.iloc[0], 'jardin')
 
     def test_snowflake_lexicon(self):
-        from jardin.database.drivers.sf import Lexicon
+        from jardin.database.clients.sf import Lexicon
         sql, params = Lexicon.standardize_interpolators(
             'SELECT * FROM users WHERE a = %(abc)s AND b = %(def)s',
             {'def': 2, 'abc': 1}


### PR DESCRIPTION
This refactoring was focused on fixing the following problems:

- Confusing names. For instance, there were a lot of things called "connection". And the word "driver" meant both the underlying db Python library (e.g. psycopg2) as well as the name of the directory containing the connection wrappers.
- Too much indirection. The base connection wrapper and the per-driver subclasses were doing a complicated dance. I tried to make it more top-down and explicit.
- Retry was being handled in an ad-hoc way (although the decorator was nice)

For more details, review each commit in order. I tried to make them stand on their own.