### PR TITLE
[Step 4] Make the global list of datasources thread-safe

### DIFF
--- a/jardin/database/__init__.py
+++ b/jardin/database/__init__.py
@@ -32,7 +32,7 @@ class Datasources(object):
         if db_name not in self._active_clients:
             clients = self._clients.get(db_name)
             if clients is None:
-                clients = self.build_clients(db_name)
+                clients = self._build_clients(db_name)
                 self._clients[db_name] = clients
             c = clients[0] if len(clients) == 1 else random.choice(clients)
             self.log_datasource(db_name, c.db_config)
@@ -40,7 +40,7 @@ class Datasources(object):
         return self._active_clients[db_name]
 
     @classmethod
-    def build_clients(self, name):
+    def _build_clients(self, name):
         clients = []
         configs = self.db_configs(name)
         for db in configs:

--- a/tests/jardin_conf_mysql.py
+++ b/tests/jardin_conf_mysql.py
@@ -1,7 +1,10 @@
 import logging
 
 DATABASES = {
-    'jardin_test': 'mysql://root:@localhost:3306/jardin_test'
+    'jardin_test': 'mysql://root:@localhost:3306/jardin_test',
+
+    # a db with multiple replica URLs. The 1st url refers to an active server. The 2nd url will fail to connect.
+    'multi_url_test': 'mysql://root:@localhost:3306/jardin_test mysql://root:@localhost:3333/jardin_test',
 }
 
 LOG_LEVEL = logging.INFO

--- a/tests/jardin_conf_pg.py
+++ b/tests/jardin_conf_pg.py
@@ -4,14 +4,17 @@ import os
 PGPORT = os.environ.get("PGPORT", 5432)
 
 DATABASES = {
-    'jardin_test': 'postgres://postgres:@localhost:%s/jardin_test' % PGPORT,
+    'jardin_test': f'postgres://postgres:@localhost:{PGPORT}/jardin_test',
     'other_test_dict_config': {
         'username': 'test',
         'password': 'test',
         'database': 'jardin_test',
         'host': 'localhost',
         'port': 1234
-    }
+    },
+
+    # a db with multiple replica URLs. The 1st url refers to an active server. The 2nd url will fail to connect.
+    'multi_url_test': f'postgres://postgres:@localhost:{PGPORT}/jardin_test postgres://postgres:@localhost:{PGPORT+1}/jardin_test',
 }
 
 LOG_LEVEL = logging.INFO

--- a/tests/jardin_conf_pg.py
+++ b/tests/jardin_conf_pg.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-PGPORT = os.environ.get("PGPORT", 5432)
+PGPORT = int(os.environ.get("PGPORT", 5432))
 
 DATABASES = {
     'jardin_test': f'postgres://postgres:@localhost:{PGPORT}/jardin_test',

--- a/tests/jardin_conf_sqlite.py
+++ b/tests/jardin_conf_sqlite.py
@@ -1,7 +1,9 @@
 import logging
 
 DATABASES = {
-    'jardin_test': 'sqlite://localhost/jardin_test.db'
+    'jardin_test': 'sqlite://localhost/jardin_test.db',
+    # a db with multiple replica URLs. The 1st url works, but the 2nd is intentionally bogus.
+    'multi_url_test': 'sqlite://localhost/jardin_test.db sqlite://localhost/bogus.db',
 }
 
 LOG_LEVEL = logging.INFO

--- a/tests/test_reset_session.py
+++ b/tests/test_reset_session.py
@@ -1,4 +1,6 @@
 import unittest
+from threading import Thread
+from time import sleep
 
 import jardin
 from jardin.database import Datasources
@@ -19,6 +21,15 @@ class TestResetSession(unittest.TestCase):
         jardin.reset_session()
         client2 = Datasources.active_client('multi_url_test')
         self.assertNotEqual(client, client2)
+
+    def test_reset_session_is_isolated_by_thread(self):
+        # calling `jardin.reset_session()` in a different thread should not affect this thread's session
+        before = Datasources.active_client('multi_url_test')
+        thread = Thread(target=jardin.reset_session)
+        thread.start()
+        thread.join()
+        after = Datasources.active_client('multi_url_test')
+        self.assertEqual(before, after)
 
 
 if __name__ == '__main__':

--- a/tests/test_reset_session.py
+++ b/tests/test_reset_session.py
@@ -1,0 +1,25 @@
+import unittest
+
+import jardin
+from jardin.database import Datasources
+
+
+class TestResetSession(unittest.TestCase):
+
+    def test_reset_session_does_nothing_when_only_one_db_url_available(self):
+        self.assertEqual(len(Datasources.db_configs('jardin_test')), 1)
+        client = Datasources.active_client('jardin_test')
+        jardin.reset_session()
+        client2 = Datasources.active_client('jardin_test')
+        self.assertEqual(client, client2)
+
+    def test_reset_session_picks_a_different_client_when_multiple_db_urls_available(self):
+        self.assertEqual(len(Datasources.db_configs('multi_url_test')), 2)
+        client = Datasources.active_client('multi_url_test')
+        jardin.reset_session()
+        client2 = Datasources.active_client('multi_url_test')
+        self.assertNotEqual(client, client2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There were 2 problems here:

1. `reset_session()` changes the active database connection as if the program was single-threaded (which was true until event-driven matching came along)
2. the list of database configurations was initialized lazily, but there was nothing to protect against multiple threads racing to do the initialization.

The first problem was solved by storing the database connections in a thread-local. This allowed me to simplify `BaseClient` since now it can act like it lives in a single-threaded world.

The second problem was solved by using a lock to guard initialization.