### PR TITLE
Uncommenting parts of the documentation

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,29 +1,29 @@
 Features
 ========
 
-..Associations
-..------------
+Associations
+------------
 
-..Belongs-to and has-many relationships can be declared as such:
+Belongs-to and has-many relationships can be declared as such:
 
-..  class Posts(jardin.Model):
-..    belongs_to = {
-..      'users': 'user_id'
-..    }
+  class Posts(jardin.Model):
+    belongs_to = {
+      'users': 'user_id'
+    }
 
-..  class Users(jardin.Model):
-..    has_many = [Posts]
+  class Users(jardin.Model):
+    has_many = [Posts]
 
-..And then used as such:
+And then used as such:
 
-..  users = Users.select()
-..  posts = users.posts()
+  users = Users.select()
+  posts = users.posts()
 
-..Or:
+Or:
 
-..  Posts.select(
-..    inner_join=[Users],
-..    where={'u.id': 123})
+  Posts.select(
+    inner_join=[Users],
+    where={'u.id': 123})
 
 Query watermarking
 ------------------
@@ -53,8 +53,6 @@ Then used as such::
   User.select(scopes = ['active', 'recent'])
 
 Which will issue this statement
-
-.. code-block:: psql
 
   SELECT * FROM users u WHERE u.active IS TRUE AND u.last_sign_up_at > ...;
 


### PR DESCRIPTION
When a user looks at the "Features" documentation on the readthedocs website or the github repo, it appears broken:

![Screen Shot 2021-05-13 at 02 23 30 PM](https://user-images.githubusercontent.com/348581/118189923-402e4400-b3f7-11eb-906b-aaf998df95dc.png)
https://jardin.readthedocs.io/en/latest/features.html

![Screen Shot 2021-05-13 at 02 24 54 PM](https://user-images.githubusercontent.com/348581/118189943-47555200-b3f7-11eb-92c1-361b0c2204aa.png)
https://github.com/instacart/jardin/blob/master/docs/features.rst

I'm not sure if this is the desired behavior or not.  This PR removes the `..`'s, so that these sections match the others.  Feel free to reject if the `..`'s are desired.  :)