### PR TITLE
Allow more exception types to trigger retries and bans

### DIFF
--- a/jardin/database/clients/mysql.py
+++ b/jardin/database/clients/mysql.py
@@ -27,8 +27,8 @@ class Lexicon(BaseLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
-    retryable_exceptions = (pymysql.InterfaceError, pymysql.OperationalError)
-    connectivity_exceptions = (pymysql.InterfaceError, pymysql.OperationalError)
+    retryable_exceptions = (pymysql.Error,)
+    connectivity_exceptions = (pymysql.DatabaseError, pymysql.InterfaceError)
 
     def connect_impl(self):
         kwargs = self.default_connect_kwargs.copy()

--- a/jardin/database/clients/pg.py
+++ b/jardin/database/clients/pg.py
@@ -42,8 +42,8 @@ class Lexicon(BaseLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
-    retryable_exceptions = (pg.OperationalError, pg.InterfaceError, pg.extensions.QueryCanceledError)
-    connectivity_exceptions = (pg.OperationalError, pg.InterfaceError)
+    retryable_exceptions = (pg.Error,)
+    connectivity_exceptions = (pg.DatabaseError, pg.InterfaceError)
 
     def connect_impl(self):
         kwargs = self.default_connect_kwargs.copy()

--- a/jardin/database/clients/sf.py
+++ b/jardin/database/clients/sf.py
@@ -31,8 +31,8 @@ class Lexicon(PGLexicon):
 class DatabaseClient(BaseClient):
 
     lexicon = Lexicon
-    retryable_exceptions = (sf.InterfaceError, sf.OperationalError)
-    connectivity_exceptions = (sf.InterfaceError, sf.OperationalError)
+    retryable_exceptions = (sf.Error,)
+    connectivity_exceptions = (sf.DatabaseError, sf.InterfaceError)
 
     def connect_impl(self):
         kwargs = dict(


### PR DESCRIPTION
There was a bug in psycopg2 prior to 2.9 that [misclassified some connection failures](https://github.com/psycopg/psycopg2/pull/1148). This prevented us from retrying in those cases. Rather than play whack-a-mole, let's just expand the notion of retryable exception to the PEP249 `Error` base class (basically, any kind of database-related error).