### PR TITLE
Support APPLICATION_NAME as a query tag for snowflake

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -66,7 +66,7 @@ jobs:
       env:
         MYSQL_PWD: password
       run: |
-        sudo apt-get install -y mysql-client
         mysql --version
         mysql -e 'create database jardin_test;' --host 127.0.0.1 --user root
         JARDIN_CONF=tests/jardin_conf_mysql.py python -m pytest tests
+

--- a/jardin/config.py
+++ b/jardin/config.py
@@ -3,6 +3,7 @@ import imp, os, logging, sys
 from jardin.instrumentation.notifier import Notifier
 
 DEFAULTS = {
+    'APPLICATION_NAME': None,
     'WATERMARK': '',
     'LOG_LEVEL': logging.INFO,
     'CACHE': {
@@ -26,7 +27,7 @@ def init():
     if INITIALIZED:
         return
 
-    global DATABASES, CACHE, WATERMARK, LOG_LEVEL, logger, notifier
+    global APPLICATION_NAME, DATABASES, CACHE, WATERMARK, LOG_LEVEL, logger, notifier
 
     config_file = imp.load_source('jardin_conf', os.environ.get('JARDIN_CONF', 'jardin_conf.py'))
 

--- a/jardin/database/clients/sf.py
+++ b/jardin/database/clients/sf.py
@@ -44,8 +44,8 @@ class DatabaseClient(BaseClient):
             schema=self.db_config.schema,
             autocommit=True
         )
-        if config.WATERMARK:
-            kwargs['session_parameters'] = dict(QUERY_TAG=config.WATERMARK)
+        if config.APPLICATION_NAME:
+            kwargs['session_parameters'] = dict(QUERY_TAG=config.APPLICATION_NAME)
         if 'warehouse' in dir(self.db_config):
             kwargs['warehouse'] = self.db_config.warehouse
         if 'authenticator' in dir(self.db_config):

--- a/jardin/database/clients/sf.py
+++ b/jardin/database/clients/sf.py
@@ -4,6 +4,7 @@ import snowflake.connector as sf
 
 from jardin.database.clients.pg import Lexicon as PGLexicon
 from jardin.database.base_client import BaseClient
+import jardin.config as config
 
 
 class Lexicon(PGLexicon):
@@ -43,6 +44,8 @@ class DatabaseClient(BaseClient):
             schema=self.db_config.schema,
             autocommit=True
         )
+        if config.WATERMARK:
+            kwargs['session_parameters'] = dict(QUERY_TAG=config.WATERMARK)
         if 'warehouse' in dir(self.db_config):
             kwargs['warehouse'] = self.db_config.warehouse
         if 'authenticator' in dir(self.db_config):


### PR DESCRIPTION
Added support to include APPLICATION_NAME in jardin_conf.py to be included on snowflake connections as the QUERY_TAG session parameters as documented here: https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters.

Watermark is already being used to identify postgres connections but the existing values don't always match the exact app name so I decided to make a new field that's opt-in and can be used consistently with how instacart-datastores-py is tagging queries.

### Testing
The snowflake adapter is currently untested through pytest due to the difficulty of testing without external connections to snowflake.

The change was validated locally by querying `"SELECT QUERY_TAG FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION()) LIMIT 1` after a query to see the query tag was successfully added.

Tests were failing because the mysql-client package couldn't be installed. It's already installed by default now https://github.com/actions/virtual-environments/issues/4797 so that step can just be skipped.